### PR TITLE
docs: add README with build instructions + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dylan Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Morse Decoder
+
+Morse Decoder is a real-time audio application that visualizes the frequency spectrum of incoming audio and decodes Morse code.
+
+## Build
+
+### Linux
+Run the configuration script to check for dependencies and then build:
+
+```bash
+./configure
+make
+```
+
+### Windows
+
+Use the Windows makefile:
+
+```bash
+make -f Makefile.win
+```
+
+## Controls
+
+- **Left/Right Arrows**: Tune the center frequency
+- **Up/Down Arrows**: Adjust gain
+- **PageUp/PageDown**: Change displayed frequency range
+- **Esc**: Exit the application
+
+## Roadmap
+
+- Packaging for easier distribution
+- Improved Morse decoding accuracy
+- Cross-platform UI enhancements
+- Network-based audio input

--- a/configure
+++ b/configure
@@ -1,0 +1,55 @@
+#!/bin/sh
+# configure - simple dependency checker for Morse Decoder
+
+missing=0
+
+check_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Error: $1 not found." >&2
+        case "$1" in
+            gcc)
+                echo "Install GCC (e.g., sudo apt install build-essential)" >&2
+                ;;
+            sdl2-config)
+                echo "Install SDL2 development files (e.g., sudo apt install libsdl2-dev)" >&2
+                ;;
+            pkg-config)
+                echo "Install pkg-config (e.g., sudo apt install pkg-config)" >&2
+                ;;
+        esac
+        missing=1
+    fi
+}
+
+check_library() {
+    if ! pkg-config --exists "$1"; then
+        echo "Error: $1 not found." >&2
+        case "$1" in
+            SDL2_ttf)
+                echo "Install SDL2_ttf (e.g., sudo apt install libsdl2-ttf-dev)" >&2
+                ;;
+            fftw3)
+                echo "Install FFTW3 (e.g., sudo apt install libfftw3-dev)" >&2
+                ;;
+        esac
+        missing=1
+    fi
+}
+
+check_command gcc
+check_command sdl2-config
+check_command pkg-config
+
+if command -v pkg-config >/dev/null 2>&1; then
+    check_library SDL2_ttf
+    check_library fftw3
+else
+    echo "Skipping library checks because pkg-config is missing." >&2
+fi
+
+if [ "$missing" -eq 0 ]; then
+    echo "All dependencies appear to be installed."
+else
+    echo "Some dependencies are missing. Please install them and run configure again." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- document project features, controls, and build instructions in new README
- add MIT license
- include configure helper to check for build dependencies

## Testing
- `./configure` *(fails: FFTW3 missing)*
- `make` *(fails: fftw3 not found)*
- `make -f Makefile.win` *(fails: Makefile.win missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af2d66208326941fcf756ce984ec